### PR TITLE
Add budget status endpoint for categories

### DIFF
--- a/backend/src/api/categories.py
+++ b/backend/src/api/categories.py
@@ -34,6 +34,11 @@ def list_categories():
     return crud.list_categories()
 
 
+@router.get("/budget-status", tags=["Categories"])
+def get_budget_status():
+    return crud.get_budget_status()
+
+
 class Budget(BaseModel):
     budget: float
 


### PR DESCRIPTION
## Summary
- implement `get_budget_status` to aggregate monthly spending per category and compare against budgets
- expose `GET /categories/budget-status` API returning budget usage summary

## Testing
- `ruff check src/crud.py src/api/categories.py`
- `ruff check .` *(fails: unused imports in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c063903728832e99928c9b1272dfb5