### PR TITLE
Warm up DB connection at startup

### DIFF
--- a/backend/src/crud.py
+++ b/backend/src/crud.py
@@ -9,7 +9,7 @@ from src.models import Category, Expense, CategoryKeyword
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://postgres:postgres@db/expenses")
 TZ_OFFSET = int(os.getenv("TZ_OFFSET_MINUTES", "-180"))
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 Session = sessionmaker(bind=engine)
 
 def now_utc():

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,7 +1,10 @@
+import logging
+
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
 from src.api.categories import router as categories_router
 from src.api.expenses import router as expenses_router
+from src import crud
 
 app = FastAPI()
 app.add_middleware(
@@ -14,6 +17,18 @@ app.add_middleware(
 
 app.include_router(categories_router, prefix="/categories")
 app.include_router(expenses_router, prefix="/expenses")
+
+
+@app.on_event("startup")
+def init_db_connection():
+    """Establish and immediately dispose of a database connection."""
+    logger = logging.getLogger(__name__)
+    try:
+        conn = crud.engine.connect()
+        conn.close()
+        crud.engine.dispose()
+    except Exception:
+        logger.exception("Failed to establish initial database connection")
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- warm up database engine on FastAPI startup, disposing the connection afterwards
- log failures during startup connection attempts
- pre-ping database connections to avoid stale sessions

## Testing
- `backend/.venv/bin/ruff check backend/src/main.py backend/src/crud.py`
- `backend/.venv/bin/python -m pytest` *(fails: No module named pytest, installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a809550832eab7038949aa18271