### PR TITLE
Add /chatid command to retrieve Telegram chat ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal Telegram bot to log expenses into a local SQLite database.
   - `/start` — quick help
   - `/sum [today|week|month]` — totals by currency
   - `/list [today|week|month]` — last 50 entries within period
+  - `/chatid` — reply with your chat ID for reminder configuration
 
 ## Quickstart
 

--- a/backend/bot.py
+++ b/backend/bot.py
@@ -137,6 +137,10 @@ async def cmd_list(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lines.append(f"{ts_str} • {r['category']}: {r['amount']:.2f} {r['currency']}{note}")
     await update.message.reply_text("\n".join(lines), parse_mode=ParseMode.MARKDOWN)
 
+async def cmd_chatid(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Return the chat ID so the user can configure reminders."""
+    await update.message.reply_text(str(update.effective_chat.id))
+
 async def on_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not update.message or not update.message.text:
         return
@@ -174,6 +178,7 @@ def main():
     app.add_handler(CommandHandler("start", cmd_start))
     app.add_handler(CommandHandler("sum", cmd_sum))
     app.add_handler(CommandHandler("list", cmd_list))
+    app.add_handler(CommandHandler("chatid", cmd_chatid))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))
 
     print("Bot is running... Press Ctrl+C to stop.")


### PR DESCRIPTION
## Summary
- expose a new `/chatid` command that replies with the sender's chat ID
- document the command in the README for easier reminder setup

## Testing
- `uv run ruff check bot.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c08d11626c832ebb7999e135f9d24c