### PR TITLE
feat: add daily budget reminder

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,8 +32,12 @@ services:
   bot:
     build: ./backend
     command: uv run bot.py
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN}
+      CHAT_ID: ${CHAT_ID}
+      BUDGET_REMINDER_HOUR: ${BUDGET_REMINDER_HOUR:-9}
     depends_on:
-      - db
+      - backend
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- implement budget reminder task calling API and sending summary
- schedule daily reminder at configurable hour
- configure bot service env vars for token, chat and schedule

## Testing
- `cd backend && uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0919a1ba8832e9a6743c431cf5583